### PR TITLE
fix: subtract function to return correct difference

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -22,7 +22,7 @@ def subtract(a,b):
     Retour:
         float: Différence de a avec b.
     """
-    return b - a
+    return a - b
 
 def multiply(a,b):
     """


### PR DESCRIPTION
The subtract() function was inverting the operands, giving b - a as an answer instead of a - b, causing all subtraction operations to return inverted results. 

### Changes:

- Changed subtract() function in operations.py to return a - b instead of b - a


Closes #3
