### PR TITLE
fix: multiply function to use multiplication operator

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -35,7 +35,7 @@ def multiply(a,b):
     Retour:
         float: Produit de a et b.
     """
-    return a ** b
+    return a * b
 
 def divide(a,b):
     """


### PR DESCRIPTION
The multiply function was incorrectly using the exponentiation operator (**) instead of the multiplication operator (*). This commit corrects the implementation to return the product of a and b.

### Changes:
- Changed multiply() function in operations.py to return a * b instead of a ** b 


Closes #2 